### PR TITLE
Fix causal-module deps, single-source version, add contributors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ authors = [
   { name="Pratinav Seth", email="pratinav.seth@lexsi.ai" },
   { name="Mohamed Bouadi", email="mohamed.bouadi@lexsi.ai" },
   { name="Utsav Avaiya", email="utsav.avaiya@lexsi.ai" },
+  { name="Yash Desai", email="yash.desai@lexsi.ai" },
+  { name="Nassim Bouarour", email="nassim.bouarour@lexsi.ai" },
   { name="Vinay Kumar Sankarapu", email="v.k@lexsi.ai" },
 ]
 maintainers = [
@@ -90,6 +92,15 @@ strict = [
     "transformers==4.56.0",
     "scikit-learn==1.7.0",
     "pyzmq==27.0.1",
+]
+causal = [
+    # Dependencies for the tabtune.causal module (treatment-effect estimation).
+    "doubleml>=0.9.0",
+    "econml>=0.14.0",
+    "dowhy>=0.11",
+    "causal-learn>=0.1.3",
+    "networkx>=2.6",
+    "jinja2>=3.0.0",
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ def read_requirements():
 
 setup(
     name="tabtune",
-    version="0.1.0",
-    author="Aditya Tanna, Pratinav Seth, Mohamed Bouadi, Utsav Avaiya, Vinay Kumar Sankarapu",
+    version="0.1.17",
+    author="Aditya Tanna, Pratinav Seth, Mohamed Bouadi, Utsav Avaiya, Yash Desai, Nassim Bouarour, Vinay Kumar Sankarapu",
     author_email="aditya.tanna@lexsi.ai",
     maintainer="Aditya Tanna",
     maintainer_email="aditya.tanna@lexsi.ai",

--- a/tabtune/TabularPipeline/pipeline.py
+++ b/tabtune/TabularPipeline/pipeline.py
@@ -362,7 +362,7 @@ class TabularPipeline:
                     torch_model.load_state_dict(checkpoint)
                     logger.info(f"[Pipeline] Successfully loaded checkpoint for {type(self.model).__name__}.")
                 else:
-                    logger.warning(f"[Pipeline] Could not determine the underlying torch model for {type(self.model)._name_} to load checkpoint.")
+                    logger.warning(f"[Pipeline] Could not determine the underlying torch model for {type(self.model).__name__} to load checkpoint.")
             except Exception as e:
                 logger.error(f"[Pipeline] Failed to load checkpoint: {e}")
             
@@ -674,7 +674,7 @@ class TabularPipeline:
                     logger.info(f"[Pipeline] Attempting to load model state from checkpoint for late-initialized model: {self.model_checkpoint_path}")
                     try:
                         self.model.load_state_dict(torch.load(self.model_checkpoint_path, map_location=torch.device()))
-                        logger.info(f"[Pipeline] Successfully loaded checkpoint for {type(self.model)._name_}.")
+                        logger.info(f"[Pipeline] Successfully loaded checkpoint for {type(self.model).__name__}.")
                     except Exception as e:
                         logger.error(f"[Pipeline] Failed to load checkpoint: {e}")
 

--- a/tabtune/__init__.py
+++ b/tabtune/__init__.py
@@ -5,8 +5,17 @@ A powerful and flexible Python library designed to simplify the training and fin
 of modern foundation models on tabular data.
 """
 
-__version__ = "0.1.0"
-__author__ = "Aditya Tanna, Pratinav Seth, Mohamed Bouadi, Utsav Avaiya, Vinay Kumar Sankarapu"
+# Version is sourced from the installed package metadata (pyproject.toml) so it
+# never drifts. The literal is only a fallback when running from a source tree
+# that hasn't been installed.
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    __version__ = _pkg_version("tabtune")
+except PackageNotFoundError:  # running from an uninstalled source checkout
+    __version__ = "0.1.17"
+
+__author__ = "Aditya Tanna, Pratinav Seth, Mohamed Bouadi, Utsav Avaiya, Yash Desai, Nassim Bouarour, Vinay Kumar Sankarapu"
 __maintainer__ = "Aditya Tanna"
 __email__ = "contact@lexsi.ai"
 __maintainer_email__ = "contact@lexsi.ai"

--- a/tabtune/causal/graph.py
+++ b/tabtune/causal/graph.py
@@ -25,8 +25,16 @@ import logging
 import re
 from typing import Any
 
-import networkx as nx
 import pandas as pd
+
+try:
+    import networkx as nx
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "The TabTune causal module requires additional dependencies "
+        "(networkx, doubleml, econml, dowhy, causal-learn, jinja2). "
+        "Install them with `pip install tabtune[causal]`."
+    ) from exc
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_causal.py
+++ b/tests/test_causal.py
@@ -1,0 +1,82 @@
+"""Smoke tests for the ``tabtune.causal`` module.
+
+These cover the lightweight, estimator-fit-free surface of the causal module
+(registry wiring, constructor validation, and sklearn-adapter typing). They are
+skipped automatically when the optional causal dependencies are not installed
+(``pip install tabtune[causal]``), so they never break a core-only CI run but
+do exercise the public API once the extra is present.
+"""
+import pytest
+
+# The causal package imports networkx at import time; skip the whole module
+# when the optional causal dependencies are absent.
+pytest.importorskip("networkx")
+
+from tabtune.causal import (  # noqa: E402
+    CausalAnalysis,
+    ESTIMATOR_REGISTRY,
+    _TabTuneSklearnAdapter,
+    as_sklearn,
+)
+
+
+def test_estimator_registry_complete():
+    expected = {
+        "dml",
+        "s_learner",
+        "t_learner",
+        "x_learner",
+        "r_learner",
+        "causal_forest",
+    }
+    assert expected.issubset(set(ESTIMATOR_REGISTRY))
+
+
+def test_causal_analysis_rejects_unknown_estimator():
+    with pytest.raises(ValueError):
+        CausalAnalysis(
+            model_name="TabPFNv26",
+            task_type="regression",
+            treatment="t",
+            outcome="y",
+            confounders=["x1", "x2"],
+            estimator="not_a_real_estimator",
+        )
+
+
+def test_causal_analysis_constructs_and_round_trips_params():
+    ca = CausalAnalysis(
+        model_name="TabPFNv26",
+        task_type="regression",
+        treatment="t",
+        outcome="y",
+        confounders=["x1", "x2"],
+        sensitive=["s"],
+        estimator="dml",
+        verbose=False,
+    )
+    assert ca.estimator == "dml"
+    assert ca.confounders == ["x1", "x2"]
+    assert ca.sensitive == ["s"]
+
+    params = ca.get_params()
+    assert params["estimator"] == "dml"
+    assert params["treatment"] == "t"
+    assert params["confounders"] == ["x1", "x2"]
+
+
+@pytest.mark.parametrize(
+    "task_type,expected_type",
+    [("classification", "classifier"), ("regression", "regressor")],
+)
+def test_adapter_estimator_type(task_type, expected_type):
+    adapter = as_sklearn(model_name="TabPFNv26", task_type=task_type)
+    assert isinstance(adapter, _TabTuneSklearnAdapter)
+    assert adapter._estimator_type == expected_type
+
+
+def test_regression_adapter_has_no_predict_proba():
+    adapter = as_sklearn(model_name="TabPFNv26", task_type="regression")
+    # The regression adapter must not advertise predict_proba (it routes
+    # through __getattr__, which raises AttributeError for regressors).
+    assert not hasattr(adapter, "predict_proba")


### PR DESCRIPTION
Targeted consistency/packaging fixes for the June release branch (`june-release`, PR #27).

### Changes
- **Causal dependencies declared.** Added a `[causal]` optional-dependency extra (`doubleml`, `econml`, `dowhy`, `causal-learn`, `networkx`, `jinja2`). `tabtune.causal.graph` imported `networkx` eagerly while none of these were declared, so `from tabtune.causal import CausalAnalysis` failed on a clean install with a cryptic `ModuleNotFoundError`. The import is now guarded and points users to `pip install tabtune[causal]`. (The heavy estimators — doubleml/econml/dowhy/causal-learn — remain lazily imported, so the module still loads with just `networkx` present.)
- **Version single-sourced.** `tabtune.__version__` now reads from the installed package metadata, so `pyproject.toml` is the one source of truth. The stale `setup.py` version (`0.1.0`) is synced to `0.1.17`; previously the version was hand-mirrored in three places and had drifted.
- **Checkpoint-logging bug.** Fixed `type(self.model)._name_` → `type(self.model).__name__` in two pipeline log lines (the single-underscore form would raise `AttributeError` if those branches were hit).
- **Contributors.** Added Yash Desai and Nassim Bouarour to the author lists.
- **Tests.** Added `tests/test_causal.py` — smoke tests for the registry, constructor validation, and adapter typing, auto-skipped when the `[causal]` extra is absent (never breaks a core-only run).

### Notes
- Author emails for the two new contributors follow the established `firstname.lastname@lexsi.ai` pattern — please correct if either differs.
- `setup.py` remains a redundant second metadata copy; recommend retiring it in a follow-up now that `pyproject.toml` fully defines the project and the version is single-sourced.
