### PR TITLE
fix(tests): skip TabPFNv3 pipeline-construction tests when TABPFN_TOKEN absent

### DIFF
--- a/tests/test_tabpfnv3.py
+++ b/tests/test_tabpfnv3.py
@@ -27,8 +27,16 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import os
+
 _HAS_TORCH = importlib.util.find_spec("torch") is not None
 requires_torch = pytest.mark.skipif(not _HAS_TORCH, reason="torch not installed")
+
+_HAS_TABPFN_TOKEN = bool(os.environ.get("TABPFN_TOKEN"))
+requires_tabpfn_token = pytest.mark.skipif(
+    not _HAS_TABPFN_TOKEN,
+    reason="requires TABPFN_TOKEN env var to download v3 weights",
+)
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 _PIN_PATH = _REPO_ROOT / "tabtune/models/tabpfnv3/finetuning/_tabtune_v3_pin.py"
@@ -239,6 +247,7 @@ class TestPipelineConstruction:
                             tuning_strategy="inference", model_params={"device": "cpu"})
         assert isinstance(p.model, TabPFNv3RegressorWrapper)
 
+    @requires_tabpfn_token
     def test_classification_finetune_builds(self):
         from tabtune import TabularPipeline
         p = TabularPipeline(model_name="TabPFNv3", task_type="classification",
@@ -247,6 +256,7 @@ class TestPipelineConstruction:
                             model_params={"device": "cpu"})
         assert p.model is not None
 
+    @requires_tabpfn_token
     def test_regression_finetune_allowed(self):
         from tabtune import TabularPipeline
         p = TabularPipeline(model_name="TabPFNv3", task_type="regression",


### PR DESCRIPTION
## What

`TestPipelineConstruction::test_classification_finetune_builds` and `test_regression_finetune_allowed` currently **fail** in any environment where `TABPFN_TOKEN` is not set (CI, fresh dev machines, reviewers). They construct a `TabularPipeline` with `tuning_strategy='finetune'`, which causes `__init__` to call `_initialize_model_variables()`, which tries to download v3 weights from HuggingFace and raises `TabPFNLicenseError`.

## Fix

Add a `requires_tabpfn_token` marker (mirrors the existing `requires_torch` pattern in the same file). When `TABPFN_TOKEN` is not set, both tests are **skipped with a clear message** rather than failing.

## Test results (without token set)

```
BEFORE:  19 passed, 2 failed   (test_classification_finetune_builds, test_regression_finetune_allowed)
AFTER:   19 passed, 2 skipped
```

Both tests still run and verify the construction path when `TABPFN_TOKEN` is available.