### PR TITLE
fix(v3): LR scheduler step-order warning + feature-name loss in TBT/meta/SFT loops

### DIFF
--- a/tabtune/TuningManager/tuning.py
+++ b/tabtune/TuningManager/tuning.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import logging
 import os
+import warnings
 from sklearn.metrics import r2_score
 
 
@@ -2727,12 +2728,21 @@ class TuningManager:
                 warmup_steps = int(total_steps * config["warmup_ratio"])
 
                 def lr_lambda(step):
-                    if step < warmup_steps:
-                        return float(step) / max(1, warmup_steps)
-                    progress = float(step - warmup_steps) / max(1, total_steps - warmup_steps)
+                    # +1: LambdaLR.__init__ calls step() before the first optimizer.step(),
+                    # consuming step 0. The offset ensures the first training batch gets
+                    # warmup LR > 0 rather than 0.
+                    s = step + 1
+                    if s < warmup_steps:
+                        return float(s) / max(1, warmup_steps)
+                    progress = float(s - warmup_steps) / max(1, total_steps - warmup_steps)
                     return max(0.01, 0.5 * (1.0 + np.cos(np.pi * progress)))
 
-                scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore", category=UserWarning,
+                        message="Detected call of `lr_scheduler.step\\(\\)`",
+                    )
+                    scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 
             iterable = tqdm(dataloader, desc=f"TabPFNv3 Meta Epoch {epoch}",
                             disable=not config["show_progress"])
@@ -2912,12 +2922,18 @@ class TuningManager:
         warmup_steps = int(total_steps * config["warmup_ratio"])
 
         def lr_lambda(step):
-            if step < warmup_steps:
-                return float(step) / max(1, warmup_steps)
-            progress = float(step - warmup_steps) / max(1, total_steps - warmup_steps)
+            s = step + 1  # offset: LambdaLR.__init__ consumes step 0 before first optimizer.step()
+            if s < warmup_steps:
+                return float(s) / max(1, warmup_steps)
+            progress = float(s - warmup_steps) / max(1, total_steps - warmup_steps)
             return max(0.01, 0.5 * (1.0 + np.cos(np.pi * progress)))
 
-        scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", category=UserWarning,
+                message="Detected call of `lr_scheduler.step\\(\\)`",
+            )
+            scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 
         for epoch in range(1, config["epochs"] + 1):
             iterable = tqdm(dataloader, desc=f"TabPFNv3 SFT Epoch {epoch}",
@@ -3067,12 +3083,21 @@ class TuningManager:
                 warmup_steps = int(total_steps * config["warmup_ratio"])
 
                 def lr_lambda(step):
-                    if step < warmup_steps:
-                        return float(step) / max(1, warmup_steps)
-                    progress = float(step - warmup_steps) / max(1, total_steps - warmup_steps)
+                    # +1: LambdaLR.__init__ calls step() before the first optimizer.step(),
+                    # consuming step 0. The offset ensures the first training batch gets
+                    # warmup LR > 0 rather than 0.
+                    s = step + 1
+                    if s < warmup_steps:
+                        return float(s) / max(1, warmup_steps)
+                    progress = float(s - warmup_steps) / max(1, total_steps - warmup_steps)
                     return max(0.01, 0.5 * (1.0 + np.cos(np.pi * progress)))
 
-                scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore", category=UserWarning,
+                        message="Detected call of `lr_scheduler.step\\(\\)`",
+                    )
+                    scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 
             iterable = tqdm(dataloader, desc=f"TabPFNv3 Reg-TBT Epoch {epoch}",
                             disable=not config["show_progress"])
@@ -3152,7 +3177,7 @@ class TuningManager:
         try:
             if hasattr(model, "fit_mode") and model.fit_mode == "batched":
                 model.fit_mode = "fit_preprocessors"
-            model.fit(X_np, y_np)
+            model.fit(X_train, y_train)
             logger.info("[TuningManager] Re-fitted v3 regressor for standard inference")
         except Exception as e:  # noqa: BLE001
             logger.warning(f"[TuningManager] Post-FT re-fit failed: {e}")


### PR DESCRIPTION
## Summary

Two bugs observed during end-to-end validation of the TabPFNv3 fine-tuning paths in example 12:

**Bug 1 — LR scheduler called before optimizer (affects meta-learning, SFT, and turn-by-turn)**

`LambdaLR.__init__` calls `step()` internally before any `optimizer.step()` is invoked. This caused:
- PyTorch's `"Detected call of lr_scheduler.step() before optimizer.step()"` UserWarning on every fine-tuning run
- The warmup function evaluating at step=0 → LR=0 for the entire **first training batch**, which is silently wasted

Fix: offset `lr_lambda` by +1 so the init-consumed step 0 maps to warmup step 1 (LR=1/warmup_steps, not 0), and suppress the false-positive warning with `warnings.catch_warnings`. Verified: warmup now ramps from `base_lr/warmup_steps` → `base_lr` cleanly with zero PyTorch warnings.

**Bug 2 — Feature-name mismatch warning in turn-by-turn regression refit**

After the TBT gradient loop, the regressor was re-fitted via `model.fit(X_np, y_np)` using numpy arrays (column names stripped). Subsequent `predict(X_test)` calls on DataFrames with named columns then triggered sklearn's `"X has feature names, but TabPFNv3RegressorWrapper was fitted without feature names"` warning.

Fix: change to `model.fit(X_train, y_train)` so the wrapper receives the original DataFrame/Series, preserving feature names through `_densify()` → `super().fit()`.

## Files changed

- `tabtune/TuningManager/tuning.py` — `import warnings` added; `lr_lambda` offset in `_finetune_tabpfnv3_meta`, `_finetune_tabpfnv3_sft`, and `_finetune_tabpfnv3_regression_turn_by_turn`; post-FT refit uses original data

## Test plan

- [x] `pytest tests/test_tabpfnv3.py -m "not slow"` — 19 passed, 2 skipped (token-guarded), 0 failed
- [x] LR schedule validation script: init LR = `base_lr/warmup_steps` (nonzero), cosine tail reaches minimum, no UserWarning emitted
- [x] All structural tests in `tests/` pass (excluding pre-existing `test_processing_summary_after_fit` failure in `test_data_processor.py` which is unrelated to this PR)