### PR TITLE
fix(docs): broken regression nav paths + missing distillation page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
       - Model Comparison: user-guide/leaderboard.md
       - Troubleshooting: user-guide/troubleshooting.md
       - Ensembling Strategies: user-guide/ensembling.md
+      - Distillation: user-guide/distillation.md
       - Causal Inference: user-guide/causal.md
 
 
@@ -51,8 +52,8 @@ nav:
       - Limix: models/limix.md
 
   - Regression:
-      - Regression Overview: framework/regression/regression.md
-      - Regression Data Processing: framework/regression/regression_data_processing.md
+      - Regression Overview: regression/regression.md
+      - Regression Data Processing: regression/regression_data_processing.md
     
 
   - Advanced Topics:


### PR DESCRIPTION
## What's broken

Two issues keeping the docs from building cleanly in strict mode:

**Broken nav paths (404s)**
The Regression section in `mkdocs.yml` referenced `framework/regression/regression.md` and `framework/regression/regression_data_processing.md`, but both files actually live under `regression/` (no `framework/` prefix). These pages were silently 404ing for anyone navigating the docs.

**Missing nav entry**
`docs/user-guide/distillation.md` was added to the branch but never wired into the nav, making it a dead page.

## Fixes

- `framework/regression/regression.md` → `regression/regression.md`
- `framework/regression/regression_data_processing.md` → `regression/regression_data_processing.md`
- Added `Distillation: user-guide/distillation.md` under User Guide

## Verified

`mkdocs build --strict` now exits cleanly with zero warnings.