### PR TITLE
fix(ensemble): task-aware default metric for TabularEnsemble

### DIFF
--- a/tabtune/ensemble/strategies.py
+++ b/tabtune/ensemble/strategies.py
@@ -363,7 +363,7 @@ class GreedyEnsembleSelection:
         self,
         ensemble_size: int = 50,
         task_type: str = "classification",
-        metric: Optional[str] = None,          # FIXED: now optional, task-aware
+        metric: Optional[str] = None,
         with_replacement: bool = True,
     ) -> None:
         if ensemble_size < 1:
@@ -373,10 +373,9 @@ class GreedyEnsembleSelection:
                 f"task_type must be 'classification' or 'regression', "
                 f"got '{task_type}'."
             )
-        # --- FIX: task-aware default metric ---
+        # task-aware default metric
         if metric is None:
             metric = "r2" if task_type == "regression" else "accuracy"
-        # --- end fix ---
         self.ensemble_size = ensemble_size
         self.task_type = task_type
         self.metric = metric

--- a/tabtune/ensemble/strategies.py
+++ b/tabtune/ensemble/strategies.py
@@ -345,8 +345,9 @@ class GreedyEnsembleSelection:
         Number of greedy iterations (default 50).
     task_type : str
         ``"classification"`` or ``"regression"``.
-    metric : str
-        Validation metric to maximise / minimise.
+    metric : str, optional
+        Validation metric to maximise / minimise.  If ``None``, chooses
+        ``"r2"`` for regression and ``"accuracy"`` for classification.
     with_replacement : bool
         If ``True`` (default) a model can be selected more than once.
 
@@ -362,7 +363,7 @@ class GreedyEnsembleSelection:
         self,
         ensemble_size: int = 50,
         task_type: str = "classification",
-        metric: str = "accuracy",
+        metric: Optional[str] = None,          # FIXED: now optional, task-aware
         with_replacement: bool = True,
     ) -> None:
         if ensemble_size < 1:
@@ -372,6 +373,10 @@ class GreedyEnsembleSelection:
                 f"task_type must be 'classification' or 'regression', "
                 f"got '{task_type}'."
             )
+        # --- FIX: task-aware default metric ---
+        if metric is None:
+            metric = "r2" if task_type == "regression" else "accuracy"
+        # --- end fix ---
         self.ensemble_size = ensemble_size
         self.task_type = task_type
         self.metric = metric

--- a/tabtune/ensemble/tabular_ensemble.py
+++ b/tabtune/ensemble/tabular_ensemble.py
@@ -99,8 +99,9 @@ class TabularEnsemble:
     task_type : str
         ``"classification"`` or ``"regression"``.
 
-    metric : str
-        Metric for weight optimisation.
+    metric : str, optional
+        Metric for weight optimisation.  If ``None``, chooses
+        ``"r2"`` for regression and ``"accuracy"`` for classification.
 
         * Classification: ``"accuracy"``, ``"log_loss"``, ``"f1_score"``
         * Regression: ``"mse"``, ``"rmse"``, ``"r2"``, ``"mae"``
@@ -164,7 +165,7 @@ class TabularEnsemble:
         models: List[Dict[str, Any]],
         ensemble_strategy: str = "greedy_selection",
         task_type: str = "classification",
-        metric: str = "accuracy",
+        metric: Optional[str] = None,          # FIXED: now optional, task-aware
         cv_folds: int = 5,
         holdout_fraction: float = 0.2,
         meta_learner: str = "lr",
@@ -204,7 +205,11 @@ class TabularEnsemble:
         self.models = models
         self.ensemble_strategy = ensemble_strategy
         self.task_type = task_type
+        # --- FIX: task-aware default metric ---
+        if metric is None:
+            metric = "r2" if task_type == "regression" else "accuracy"
         self.metric = metric
+        # --- end fix ---
         self.cv_folds = cv_folds
         self.holdout_fraction = holdout_fraction
         self.meta_learner = meta_learner

--- a/tabtune/ensemble/tabular_ensemble.py
+++ b/tabtune/ensemble/tabular_ensemble.py
@@ -165,7 +165,7 @@ class TabularEnsemble:
         models: List[Dict[str, Any]],
         ensemble_strategy: str = "greedy_selection",
         task_type: str = "classification",
-        metric: Optional[str] = None,          # FIXED: now optional, task-aware
+        metric: Optional[str] = None,      
         cv_folds: int = 5,
         holdout_fraction: float = 0.2,
         meta_learner: str = "lr",
@@ -205,11 +205,10 @@ class TabularEnsemble:
         self.models = models
         self.ensemble_strategy = ensemble_strategy
         self.task_type = task_type
-        # --- FIX: task-aware default metric ---
+        # task-aware default metric
         if metric is None:
             metric = "r2" if task_type == "regression" else "accuracy"
         self.metric = metric
-        # --- end fix ---
         self.cv_folds = cv_folds
         self.holdout_fraction = holdout_fraction
         self.meta_learner = meta_learner


### PR DESCRIPTION
## Description

Fix the task-unaware default metric that causes regression ensembles to fail when no metric is explicitly provided.

## Problem Solved

`TabularEnsemble` and `GreedyEnsembleSelection` defaulted to `"accuracy"` regardless of `task_type`.

This caused the documented default regression workflow to fail during `.fit()` because `"accuracy"` is not a valid regression metric.

#### Fixes : #38 

## What's Changed

- Changed the default `metric` from `"accuracy"` to `None`.
- Automatically select `"r2"` for regression.
- Continue using `"accuracy"` for classification.
- Apply the same task-aware default in `GreedyEnsembleSelection`.
- Preserve explicitly provided metrics.

## How It Works

```text
task_type
    ↓
metric is None?
    ↓
Yes
 ├── regression     → "r2"
 └── classification → "accuracy"
````

The resolved metric is then propagated to the ensemble strategy and used by downstream evaluation and leaderboard logic.

## Feature

Regression ensembles can now be created with the default configuration:

```python
ensemble = TabularEnsemble(
    models=models,
    task_type="regression",
)
```

without requiring an explicit metric.

## Performance Impact

No meaningful performance impact is expected. The change only resolves the default metric once during initialization.
