### PR TITLE
docs: fix broken OrionMSP regression example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ X, y = fetch_california_housing(return_X_y=True)
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
 
 pipeline = TabularPipeline(
-    model_name="OrionMSP",
+    model_name="TabICLv2",
     task_type="regression",
     tuning_strategy="inference",
     tuning_params={


### PR DESCRIPTION
## Description

The README's canonical regression example should run end-to-end without modification, using a model that actually supports regression (e.g. `Mitra`, `TabICLv2`, or `TabPFNv26` — all MIT/commercial-friendly and in the registry's regression capable list).